### PR TITLE
GET /supports?{filters for proposal and participant}

### DIFF
--- a/app/resources/support_resource.rb
+++ b/app/resources/support_resource.rb
@@ -1,5 +1,22 @@
 require 'jsonapi/resource'
 
 class SupportResource < Base
+  has_one :participant
   has_one :proposal
+
+  filters :proposal_id, :participant_id
+
+  class << self
+    def apply_filter(records, filter, value, options = {})
+      value = fix_filter_value(value)
+      super(records, filter, value, options)
+    end
+
+    private
+
+      # Bug in JR wraps filter values in an array.
+      def fix_filter_value(value)
+        value.is_a?(Array) ? value.first : value
+      end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,5 @@ Rails.application.routes.draw do
     resources :supports, shallow: true, only: [:create, :destroy]
     resources :suggestions, shallow: true
   end
+  resources :supports, only: [:index]
 end

--- a/spec/resources/support_resource_spec.rb
+++ b/spec/resources/support_resource_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe SupportResource do
+  describe '.apply_filter' do
+    let(:records) { double('a model, actually', where: true) }
+    let(:filter)  { double('filter') }
+    let(:value)   { 'somevalue' }
+
+    it 'filters with a string value even if this is passed in as an array' do
+      expect(records).to receive(:where).with(filter => value)
+
+      described_class.apply_filter(records, filter, [value])
+    end
+
+    it 'and filters with a string value when this is passed in as a string as expected' do
+      expect(records).to receive(:where).with(filter => value)
+
+      described_class.apply_filter(records, filter, value)
+    end
+  end
+end


### PR DESCRIPTION
Needed for oliverbarnes/participate/issues/86, to find out if a proposal is already supported when clicking on the support button. 

Filtering is the way I found to make this work between ember-jsonapi-resources and jsonapi-resources, in the future perhaps a clearer endpoint could be implemented.

Also, currently the related resources links are coming through as uris to relationships, but I'd like to keep the endpoints as flat (top level) as possible to keep things simple. Opening a separate issue to customize the base resource to return top level endpoints.
